### PR TITLE
Allow setting the outputPath in the config

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ module.exports = function swagger(sails) {
         basePath: '/',
         schemes: ['http'],
         consumes: ['application/json'],
-        produces: ['application/json']
+        produces: ['application/json'],
+        outputPath: 'public/spec.json'
       }
     },
     initialize: function initialize(cb) {
@@ -655,7 +656,7 @@ module.exports = function swagger(sails) {
 
       var output = JSON.stringify(spec, null, 2);
 
-      fs.writeFileSync('public/spec.json', output);
+      fs.writeFileSync(sails.config[this.configKey].outputPath, output);
     }
   }
 };


### PR DESCRIPTION
I just did this visually, didn't test it. It allows a user to configure the path to output the spec file to
